### PR TITLE
InfluxDB 0.9.x support for influxdb-check

### DIFF
--- a/bin/check-influxdb-query.rb
+++ b/bin/check-influxdb-query.rb
@@ -76,7 +76,7 @@ class CheckInfluxdbQuery < Sensu::Plugin::Check::CLI
          short: '-q QUERY',
          long: '--query QUERY',
          required: true,
-         description: 'Query to run. See http://influxdb.com/docs/v0.8/api/query_language.html'
+         description: 'Query to run. See https://influxdb.com/docs/v0.9/query_language/query_syntax.html'
 
   option :alias,
          short: '-a ALIAS',

--- a/bin/check-influxdb.rb
+++ b/bin/check-influxdb.rb
@@ -57,7 +57,7 @@ class CheckInfluxDB < Sensu::Plugin::Check::CLI
          default: false
 
   option :timeout,
-         description:            'Seconds to wait for the connection to open or read (default: 1.0s)',
+         description: 'Seconds to wait for the connection to open or read (default: 1.0s)',
          short: '-t SECONDS',
          long: '--timeout SECONDS',
          proc: proc(&:to_f),
@@ -69,11 +69,12 @@ class CheckInfluxDB < Sensu::Plugin::Check::CLI
     http.read_timeout = config[:timeout]
     http.use_ssl = config[:ssl]
     http.start do
-      status = JSON.parse(http.get('/ping').body)
-      if status == { 'status' => 'ok' }
-        ok status.to_s
+      response = http.get('/ping')
+      status_line = "#{response.code} #{response.message}"
+      if response.is_a?(Net::HTTPSuccess)
+        ok status_line
       else
-        critical status.to_s
+        critical status_line
       end
     end
   rescue => e

--- a/sensu-plugins-influxdb.gemspec
+++ b/sensu-plugins-influxdb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsInfluxdb::Version::VER_STRING
 
-  s.add_runtime_dependency 'influxdb',     '0.1.8'
+  s.add_runtime_dependency 'influxdb',     '0.2.2'
   s.add_runtime_dependency 'jsonpath',     '0.5.6'
   s.add_runtime_dependency 'dentaku',      '1.2.4'
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'


### PR DESCRIPTION
Looking forward to having this plugin support InfluxDB 0.9. I was glad to see that there is already a PR in progress for it (#1) that modifies the metrics-influxdb check for InfluxDB 0.9. But there are also changes required in influxdb-check.rb, so I opened another PR for that. And it fixes issue #2.

After this PR being merged, it would not work anymore with InfluxDB 0.8. That raises the question how backwards compatibility is handled with sensu-plugins. The InfluxDB ruby client does not support both InfluxDB 0.8 and InfluxDB 0.9. If you still need InfluxDB 0.8 support you have to use an old version of the client gem.

I see that in #1 there is some effort to support both versions, but as I understand it you would have to have to use the right ruby script and additionally have to require the matching influxdb-ruby client gem. Couldn't this lead to confusion? InfluxDB 0.8 is no longer under active development, so everyone eventually has to upgrade to 0.9 anyway. Maybe it would be sufficient to just increment the plugin major version number?

**Changes:**
Update check-influxdb.rb for InfluxDB 0.9. The API of the /ping check
has been modified in InfluxDB 0.9 to return an empty body and a status
of "204 No Content" on success.

The influxdb-query-check does not need modification. It just requires a
recent ruby client with InfluxDB 0.9 support.
