### PR TITLE
Fix broken link to developer guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-[Development Documentation](http://sensu-plugins.github.io/development/)
+[Development Documentation](http://sensu-plugins.io/docs/developer_guidelines.html)


### PR DESCRIPTION
The link to the development documentation was broken. I assume it should lead to the developer guidelines and fixed it accordingly. Please check if that is the correct link target.
