### PR TITLE
InfluxDB::Client requires symbolized keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 ### Changed
+- updated metrics-influxdb.rb to symbolize keys for InfluxDB::Client
 - updated influxdb gem to 0.2.2
-- updated metrcis-influxdb.rb to support influxdb 0.9.x
+- updated metrics-influxdb.rb to support influxdb 0.9.x
 - updated README.md file
 
 ## [0.0.3] - 2015-07-14

--- a/bin/metrics-influxdb.rb
+++ b/bin/metrics-influxdb.rb
@@ -36,7 +36,10 @@ class SensuToInfluxDB < Sensu::Handler
   def filter; end
 
   def handle
-    opts = settings['influxdb'].inject({}) {|sym, (k,v)| sym[k.to_sym] = v; sym}
+    opts = settings['influxdb'].each_with_object({}) do |(k, v), sym|
+      sym[k.to_sym] = v
+    end
+
     database = opts[:database]
 
     influxdb_data = InfluxDB::Client.new database, opts

--- a/bin/metrics-influxdb.rb
+++ b/bin/metrics-influxdb.rb
@@ -36,8 +36,8 @@ class SensuToInfluxDB < Sensu::Handler
   def filter; end
 
   def handle
-    opts = settings['influxdb']
-    database = opts['database']
+    opts = settings['influxdb'].inject({}) {|sym, (k,v)| sym[k.to_sym] = v; sym}
+    database = opts[:database]
 
     influxdb_data = InfluxDB::Client.new database, opts
 


### PR DESCRIPTION
Influx config loaded from JSON has strings for keys. InfluxDB::Client at some point changed to requiring symbols for the keys.
