### PR TITLE
Adding support for https in check-influxdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
-- nothing
+- added support for https in check-influxdb.
+- pass ssl arguments to the influxdb object in check-influxdb-query.
+- renamed the config option in check-influxdb from ssl to verify_ssl.
+- changed README to update the config option ssl_ca_cert.
 
 ### [0.0.3] - 2015-08-10
 - updated metrics-influxdb.rb to symbolize keys for InfluxDB::Client

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
         "time_precision": "s",
         "use_ssl"       : false,
         "verify_ssl"    : true,
-        "ssl_ca_cert"   : false,
+        "ssl_ca_cert"   : "path to the ca certificate file",
         "auth_method"   : "params",
         "initial_delay" : 0.01,
         "max_delay"     : 30,

--- a/bin/check-influxdb-query.rb
+++ b/bin/check-influxdb-query.rb
@@ -54,6 +54,25 @@ class CheckInfluxdbQuery < Sensu::Plugin::Check::CLI
          default: '8086',
          description: 'InfluxDB port'
 
+  option :use_ssl,
+         description: 'Turn on/off SSL (default: false)',
+         short: '-s',
+         long: '--use_ssl',
+         boolean: true,
+         default: false
+
+  option :verify_ssl,
+         description: 'Turn on/off using SSL certificate (default: false)',
+         short: '-v',
+         long: '--verify_ssl',
+         boolean: true,
+         default: false
+
+  option :ssl_ca_cert,
+         description: 'Path to the ssl ca certificate to connect to the InfluxDB server',
+         short: '-c CA_CERT',
+         long: '--ssl_ca_cert CA_CERT'
+
   option :database,
          short: '-d DATABASE',
          long: '--database DATABASE',
@@ -130,6 +149,9 @@ class CheckInfluxdbQuery < Sensu::Plugin::Check::CLI
     influxdb = InfluxDB::Client.new config[:database],
                                     host: config[:host],
                                     port: config[:port],
+                                    use_ssl: config[:use_ssl],
+                                    verify_ssl: config[:verify_ssl],
+                                    ssl_ca_cert: config[:ssl_ca_cert],
                                     username: config[:username],
                                     password: config[:password]
 

--- a/bin/check-influxdb.rb
+++ b/bin/check-influxdb.rb
@@ -13,8 +13,6 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: uri
-#   gem: json
 #
 # USAGE:
 #   #YELLOW
@@ -28,9 +26,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'net/http'
-require 'uri'
-require 'json'
+require 'net/https'
 
 #
 # Check InfluxDB
@@ -49,12 +45,24 @@ class CheckInfluxDB < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 8086
 
-  option :ssl,
+  option :use_ssl,
          description: 'Turn on/off SSL (default: false)',
          short: '-s',
-         long: '--ssl',
+         long: '--use_ssl',
          boolean: true,
          default: false
+
+  option :verify_ssl,
+         description: 'Turn on/off using SSL certificate (default: false)',
+         short: '-v',
+         long: '--verify_ssl',
+         boolean: true,
+         default: false
+
+  option :ssl_ca_cert,
+         description: 'Path to the ssl ca certificate to connect to the InfluxDB server',
+         short: '-c CA_CERT',
+         long: '--ssl_ca_cert CA_CERT'
 
   option :timeout,
          description: 'Seconds to wait for the connection to open or read (default: 1.0s)',
@@ -67,7 +75,13 @@ class CheckInfluxDB < Sensu::Plugin::Check::CLI
     http = Net::HTTP.new(config[:host], config[:port])
     http.open_timeout = config[:timeout]
     http.read_timeout = config[:timeout]
-    http.use_ssl = config[:ssl]
+    http.use_ssl = config[:use_ssl]
+    if config[:verify_ssl]
+      http.ca_file = config[:ssl_ca_cert]
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    else
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
     http.start do
       response = http.get('/ping')
       status_line = "#{response.code} #{response.message}"


### PR DESCRIPTION
Summary:
Adding support for https in check-influxdb.
Passing ssl arguments to the influxdb object  in check-influxdb-query.
Renaming the config option in check-influxdb from ssl to verify_ssl, so its consistent.
Changing README to update the config option ssl_ca_cert.
