### PR TITLE
Tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 - Line protocol mutator extension
+- added tags support for metrics-influxdb.rb
 
 ### [0.0.5] - 2015-10-19
 - added support for https in check-influxdb.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
     }
 }
 ```
+To ship additional tags to your metrics via metrics-influxdb.rb (only available in influxdb >= 0.9), just add a tags block inside your check.
 
 ## Installation
 

--- a/bin/metrics-influxdb.rb
+++ b/bin/metrics-influxdb.rb
@@ -48,6 +48,7 @@ class SensuToInfluxDB < Sensu::Handler
     metric_name = @event['check']['name']
 
     metric_raw = @event['check']['output']
+    tags = @event['check']['tags']
 
     data = []
     metric_raw.split("\n").each do |metric|
@@ -62,6 +63,7 @@ class SensuToInfluxDB < Sensu::Handler
                 values: { value: value },
                 timestamp: time
               }
+      point[:tags].merge!(tags) unless tags.nil?
       data.push(point)
     end
     influxdb_data.write_points(data)


### PR DESCRIPTION
I've added tag support for metric-influxdb so that with a check like 

``` javascript
{
  "checks": {
    "my-check": {
      "type": "metric",
      "command": "/opt/sensu/embedded/bin/metrics-load.rb --scheme 'test' --per-core",
      "handlers": ["influxdb"],
      "standalone":true,
      "interval": 30,
      "tags": {"foo": "bar"}
    }
}
```

 (this will add the tag "foo" with the value "bar" )
This is especially interesting in combination with mutators and check token substitution, which can e.g. append different tags based on the environment the check is running in
