### PR TITLE
Fix Option Tag in check-influxdb-query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 - Line protocol mutator extension
 - added tags support for metrics-influxdb.rb
+- Fixed option tag in check-influxdb-query
 
 ### [0.0.5] - 2015-10-19
 - added support for https in check-influxdb.

--- a/bin/check-influxdb-query.rb
+++ b/bin/check-influxdb-query.rb
@@ -70,7 +70,7 @@ class CheckInfluxdbQuery < Sensu::Plugin::Check::CLI
 
   option :ssl_ca_cert,
          description: 'Path to the ssl ca certificate to connect to the InfluxDB server',
-         short: '-c CA_CERT',
+         short: '-C CA_CERT',
          long: '--ssl_ca_cert CA_CERT'
 
   option :database,


### PR DESCRIPTION
The ssl_ca_cert option short tag was the same as the option tag for setting a critical threshold. Changed the tag to eliminate the conflict
