### PR TITLE
Supress warning if only checking for a return value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - metrics-influxdb.rb will now create the database if needed
 - metrics-influxdb.rb can now be configured to use a specific settings block
 
+### [0.0.6] - 2016-04-18
+- supress warning if only checking for an existing return value in check-influxdb-query.
+
 ### [0.0.5] - 2015-10-19
 - added support for https in check-influxdb.
 - pass ssl arguments to the influxdb object in check-influxdb-query.

--- a/bin/check-influxdb-query.rb
+++ b/bin/check-influxdb-query.rb
@@ -165,6 +165,8 @@ class CheckInfluxdbQuery < Sensu::Plugin::Check::CLI
 
     if config[:noresult] && value.empty?
       critical "No result for query '#{query_name}'"
+    elsif config[:noresult] && !config[:jsonpath] && !value.empty?
+      ok "Value returned for query '#{query_name}'"
     end
 
     if config[:jsonpath]


### PR DESCRIPTION
This is for cases in which the actual value is not important but the fact that influx is returning a proper value is.
