### PR TITLE
Fix typo's in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the following to `/etc/sensu/conf.d/influx.conf` "plugin expects `influxdb` 
     }
 }
 ```
-Then add the following to your `/ect/sensu/conf.d/handlers.conf`:
+Then add the following to your `/etc/sensu/conf.d/handlers.conf`:
 ```
 {
   "handlers": {
@@ -60,7 +60,7 @@ Setting "status" to true will store the metric using the status as the value and
 ## Usage - mutator-influxdb-line-protocol.rb
 Add the mutator-influxdb-line-protocol.rb file into /etc/sensu/extensions/
 
-Then add the following to your `/ect/sensu/conf.d/handlers.conf`:
+Then add the following to your `/etc/sensu/conf.d/handlers.conf`:
 ```
 {
   "handlers": {


### PR DESCRIPTION
There were two references to `/ect/sensu/...`. Change them both to `/etc/sensu/...`